### PR TITLE
CI で実行される Node.js に現在リリースされているバージョンを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ '10', '12', '14' ]
+        node-version: [ '10', '12', '14', '16', '18' ]
     steps:
       - name: Setup Node
         uses: actions/setup-node@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ '10', '12', '14', '16', '18' ]
+        node-version: [ '14', '16', '18' ]
     steps:
       - name: Setup Node
         uses: actions/setup-node@v1


### PR DESCRIPTION
Node.js 16, 18 を追加しました。
Ref: https://nodejs.org/ja/about/releases/

もし EOL のバージョンはサポート対象としないのであれば、 10, 12 を削除しようと考えてます。