### PR TITLE
Reduce size by including only lib directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Japanese holidays",
   "main": "lib/holiday_jp.js",
   "types": "lib/holiday_jp.d.ts",
+  "files": ["lib"],
   "scripts": {
     "test": "mocha --require should test/*.js",
     "generate": "git submodule update; cd holiday_jp/; git fetch origin master; git reset --hard origin/master; cd ../; node scripts/generate.js",


### PR DESCRIPTION
Currently all files in this project are included in the npm package, which needlessly bloats the package size.
This PR reduces the size by specifying `lib` in `files` field in `package.json`.


Before
```
package size:  64.4 kB
unpacked size: 876.1 kB
```
After
```
package size:  13.7 kB
unpacked size: 213.1 kB
```

It was not clear to me whether the `release` directory should be included.
I would add it if necessary.