### PR TITLE
Update Node.js versions in GitHub Actions due to v14 EOL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ '14', '16', '18' ]
+        node-version: [ '16', '18' ]
     steps:
       - name: Setup Node
         uses: actions/setup-node@v1


### PR DESCRIPTION
This commit updates the Node.js versions used in our GitHub Actions workflow in response to the EOL of Node.js v14.

Changes:
- Removed Node.js v14 from the testing matrix
- Now testing against Node.js v16 and v18

By removing the EOL version and focusing on v16 and v18, we can ensure that our application remains compatible with the latest and most stable releases of Node.js.