### PR TITLE
Update Node.js versions in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ '16', '18' ]
+        node-version: [ '18', '20', '22' ]
     steps:
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,12 @@ jobs:
         node-version: [ '16', '18' ]
     steps:
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Check out source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup
         run: npm install


### PR DESCRIPTION
This pull request updates the Node.js versions in the GitHub Actions workflow file `ci.yml`. The Node.js versions have been changed from `16` and `18` to `18`, `20`, and `22`. Additionally, the `actions/setup-node` and `actions/setup-checkout` actions have been bumped to their latest versions (`v4`). These updates address the end-of-life (EOL) of Node.js v14 and ensure that the workflow is using the latest versions of the actions.