### PR TITLE
Use `npm ci` in CI to fix scheduled test failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup
-        run: npm install
+        run: npm ci
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
ref: https://github.com/holiday-jp/holiday_jp-js/issues/72

Alternative to #73.

`.github/workflows/ci.yml` runs `npm install` and then verifies that the
working tree has no uncommitted diff. Recent npm regenerates
`package-lock.json` on `npm install` (dropping `peer: true` from optional
esbuild subdeps, etc.), which trips that check and has been failing the
scheduled runs since 2025/8/4.

This PR switches the CI step to `npm ci`, which installs strictly from
the lockfile without mutating it. That is the intended tool for CI and
fixes the root cause; regenerating the lockfile (as in #73) is only a
temporary fix and will drift again on the next npm change.